### PR TITLE
Remoção de rich text desnecessário.

### DIFF
--- a/store/blocks/footer/footer.json
+++ b/store/blocks/footer/footer.json
@@ -5,8 +5,7 @@
   "footer-layout.desktop": {
     "children": [
       "flex-layout.row#footer-1-desktop",
-      "flex-layout.row#footer-2-desktop",
-      "flex-layout.row#footer-3-desktop"
+      "flex-layout.row#footer-2-desktop"
     ]
   },
   "flex-layout.row#footer-1-desktop": {
@@ -60,19 +59,6 @@
     }
   },
 
-  "flex-layout.row#footer-3-desktop": {
-    "children": ["rich-text#footer"],
-    "props": {
-      "blockClass": "credits"
-    }
-  },
-  "rich-text#footer": {
-    "props": {
-      "text": "All stock and product photos are from photos.icons8.com",
-      "blockClass": "footer"
-    }
-  },
-
   "footer-layout.mobile": {
     "children": [
       "flex-layout.row#1-footer-mobile",
@@ -90,8 +76,7 @@
   "flex-layout.col#footer-1-mobile": {
     "children": [
       "accepted-payment-methods",
-      "social-networks",
-      "rich-text#footer-mobile"
+      "social-networks"
     ],
     "props": {
       "blockClass": "payment-methods",
@@ -106,11 +91,5 @@
       "paddingBottom": 4
     },
     "children": ["vtex.menu@2.x:menu#footer-mobile"]
-  },
-  "rich-text#footer-mobile": {
-    "props": {
-      "text": "All stock and product photos are from photos.icons8.com",
-      "blockClass": "footer"
-    }
   }
 }

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -62,11 +62,6 @@
   font-size: 14px;
 }
 
-.flexRowContent--credits :global(.vtex-menu-2-x-styledLink) {
-  color: #ccc;
-  font-size: 14px;
-}
-
 .flexRowContent--main-header :global(.vtex-menu-2-x-styledLink) {
   color: #ccc;
   font-size: 15px;


### PR DESCRIPTION
No final da pagina avia um richt-text dando creditos ao photos.icons8.com pela imagens usada no site. Como todas imagens foram removida, não existe mais necessidade dele.