### PR TITLE
Removi o antigo formulário que estava conflitante

### DIFF
--- a/store/blocks/leads.jsonc
+++ b/store/blocks/leads.jsonc
@@ -63,16 +63,5 @@
       "textColor": "c-muted-5",
       "blockClass": "leadsSubTitle"
     }
-  },
-  "newsletter-form": {
-    "props": {
-      "blockClass": "leadsForm"
-    },
-    "children": [
-      "newsletter-input-email",
-      "newsletter-input-name",
-      "newsletter-input-phone",
-      "newsletter-submit"
-    ]
   }
 }


### PR DESCRIPTION
O antigo formulário as vezes aparecia no lugar do novo em react. Tirei ele e deixei só o react
